### PR TITLE
✨: vertically center TOC and add active section highlight

### DIFF
--- a/components/Blog/TableOfContents.js
+++ b/components/Blog/TableOfContents.js
@@ -1,31 +1,28 @@
 import { useEffect, useState } from "react";
 
 const TableOfContents = ({ headings }) => {
-  const [activeId, setActiveId] = useState("");
+  const [activeId, setActiveId] = useState(headings[0]?.id ?? "");
 
   useEffect(() => {
     if (headings.length === 0) return;
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            setActiveId(entry.target.id);
-          }
-        });
-      },
-      {
-        rootMargin: "0% 0% -70% 0%",
-        threshold: 0,
+    const updateActive = () => {
+      const headingEls = headings
+        .map(({ id }) => document.getElementById(id))
+        .filter(Boolean);
+
+      let currentId = headings[0]?.id ?? "";
+      for (const el of headingEls) {
+        if (el.getBoundingClientRect().top < 100) {
+          currentId = el.id;
+        }
       }
-    );
+      setActiveId(currentId);
+    };
 
-    headings.forEach(({ id }) => {
-      const el = document.getElementById(id);
-      if (el) observer.observe(el);
-    });
-
-    return () => observer.disconnect();
+    updateActive();
+    window.addEventListener("scroll", updateActive, { passive: true });
+    return () => window.removeEventListener("scroll", updateActive);
   }, [headings]);
 
   if (headings.length === 0) return null;
@@ -35,15 +32,17 @@ const TableOfContents = ({ headings }) => {
       <p className="text-slate-900 dark:text-white text-xs font-semibold mb-3 uppercase tracking-wider">
         On this page
       </p>
-      <ul className="space-y-1.5">
+      <ul className="space-y-0">
         {headings.map(({ id, text, level }) => (
-          <li key={id} className={level === 3 ? "pl-3" : ""}>
+          <li key={id}>
             <a
               href={`#${id}`}
-              className={`text-sm leading-snug block py-0.5 transition-colors duration-150 ${
+              className={`text-sm leading-snug block py-1 border-l-2 transition-all duration-150 ${
+                level === 3 ? "pl-5" : "pl-3"
+              } ${
                 activeId === id
-                  ? "text-slate-900 dark:text-white font-medium"
-                  : "text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+                  ? "border-slate-700 dark:border-slate-300 text-slate-900 dark:text-white font-medium"
+                  : "border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 hover:border-slate-300 dark:hover:border-slate-600"
               }`}
               onClick={(e) => {
                 e.preventDefault();

--- a/pages/blogs/[slug].js
+++ b/pages/blogs/[slug].js
@@ -76,10 +76,12 @@ const BlogPost = ({ readingTime, frontMatter, slug, source, headings }) => {
             ogImage={frontMatter.ogImage}
             slug={slug}
           />
-          <div className="hidden xl:block">
-            <aside className="sticky top-20 pl-10">
-              <TableOfContents headings={headings} />
-            </aside>
+          <div className="hidden xl:block xl:self-stretch">
+            <div className="sticky top-0 h-screen flex items-center">
+              <aside className="pl-10 overflow-y-auto max-h-[calc(100vh-8rem)]">
+                <TableOfContents headings={headings} />
+              </aside>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- TOC now stays at the **vertical center of the viewport** while scrolling, using a `sticky top-0 h-screen flex items-center` wrapper instead of the previous `sticky top-20`
- Replaced `IntersectionObserver` with a `scroll` event listener that reliably tracks the **last heading scrolled past** (checks `getBoundingClientRect().top < 100`)
- Added a **left-border indicator** on the active TOC item, with a subtle hover border on inactive items

## Test plan

- [ ] Open a blog post on an XL+ screen width
- [ ] Scroll through the article and verify the TOC stays vertically centered throughout
- [ ] Verify the active item in the TOC updates as you scroll past each section heading
- [ ] Verify clicking a TOC link scrolls to the correct section and highlights it
- [ ] Check both light and dark mode