### PR TITLE
💄: refine blog typography, code blocks, and image sizing

### DIFF
--- a/blogs/2025-04-27-open-manus.md
+++ b/blogs/2025-04-27-open-manus.md
@@ -34,7 +34,12 @@ An agent is an autonomous system designed to perceive its environment, make deci
 
 ReAct agent is a simple but useful concept in agent, proposed by the OpenAI researcher Shunyu Yao. It combines both reasoning and execution in an interleaved manner to improve the agent's performance in tasks. ReAct agents iteratively think and reason about the current task, and then decide whether to use tools to complete the current task. If the tools are needed, it will take the action and update the internal state. The general workflow is shown below.
 
-![Manus](https://franklee.xyz/public_assets/blog_media/2025-04-27-open-manus/react.png)
+<p>
+    <img src="https://franklee.xyz/public_assets/blog_media/2025-04-27-open-manus/react.png" width="400" alt>
+    <center>
+    <em>ReAct agent workflow</em>
+    </center>
+</p>
 
 ### 3. Function Calling
 
@@ -81,7 +86,7 @@ print(response.choices[0].message.tool_calls)
 
 The API will return a response like below. The response contains the name(s) of the function(s) to use, and the corresponding parameters structured in json format. In this way, the developer can look up for the actual function code and execute that function with the given parameters.
 
-```text
+```python
 [
     ChatCompletionMessageToolCall(
         id='call_xFu1qgsnPzzviCxNvDNcXf41',
@@ -108,14 +113,18 @@ This subsection cover the major modules in the OpenManus project. Each module is
 
 #### Agents
 
-![Agents](https://franklee.xyz/public_assets/blog_media/2025-04-27-open-manus/agent.png)
+<p>
+    <img src="https://franklee.xyz/public_assets/blog_media/2025-04-27-open-manus/agent.png" width="800" alt>
+    <center>
+    <em>Agents</em>
+    </center>
+</p>
 
 The [agent](https://github.com/mannaandpoem/OpenManus/tree/main/app/agent) module is the entrypoint of the agent system. It is responsible for the overall workflow of the agent system. As shown in the diagram above, the agents are organized in a hierarchical structure and the `ReActAgent` and `ToolCallAgent` define the core logic flow for task automation. Each class' duty is explained below:
 
 1. BaseAgent
 
    This is the most fundamental class of an agent, it mainly takes care of the properties and states of the agent. For example, it has a name and description and also a system prompt to interact with the LLMs. The run method is the entrypoint of this agent, in run, the agent basically runs the step method repeatedly until its agent becomes FINISHED or IDLE.
-
    - Finished: means the agent has finished the task
    - IDLE: means the agent has not finished the task but has reached the max number of steps, so it is forced to terminate
 
@@ -235,7 +244,12 @@ The [agent](https://github.com/mannaandpoem/OpenManus/tree/main/app/agent) modul
 
 #### Tools
 
-![Tools](https://franklee.xyz/public_assets/blog_media/2025-04-27-open-manus/tools.png)
+<p>
+    <img src="https://franklee.xyz/public_assets/blog_media/2025-04-27-open-manus/tools.png" width="800" alt>
+    <center>
+    <em>Tools</em>
+    </center>
+</p>
 
 The `tools` module implements a collection to external tools which can be used by the agent to retrive information and reason.
 
@@ -254,7 +268,6 @@ The `tools` module implements a collection to external tools which can be used b
 4. DeepResearch
 
    The Deep Research tool is a tool that can be used to perform a complete research cycle. It can be seen as an extension of the chat completion and web search by following the following steps:
-
    - Optimize the search query using LLM
    - Perform a complete research cycle:
    - Search on the web
@@ -290,7 +303,12 @@ The `tools` module implements a collection to external tools which can be used b
 
 The sandbox module is responsible for creating an isolated environment for the agent to execute the task. It is a wrapper for the Docker SDK and provides a unified interface for the agent to interact with the sandbox.
 
-![  ](https://franklee.xyz/public_assets/blog_media/2025-04-27-open-manus/sandbox.png)
+<p>
+    <img src="https://franklee.xyz/public_assets/blog_media/2025-04-27-open-manus/sandbox.png" width="800" alt>
+    <center>
+    <em>Sandbox</em>
+    </center>
+</p>
 
 1. BaseSandboxClient
 
@@ -316,7 +334,12 @@ The sandbox module is responsible for creating an isolated environment for the a
 
 Memory is a module that manages the conversation history (context) of the agent. It is responsible for storing the messages and the states of the agent.
 
-![Memory](https://franklee.xyz/public_assets/blog_media/2025-04-27-open-manus/memory.png)
+<p>
+    <img src="https://franklee.xyz/public_assets/blog_media/2025-04-27-open-manus/memory.png" width="400" alt>
+    <center>
+    <em>Memory</em>
+    </center>
+</p>
 
 1. Message
 

--- a/components/Blog/Blog.js
+++ b/components/Blog/Blog.js
@@ -1,11 +1,10 @@
 import React from "react";
-import Image from "next/image";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 import rehypeSlug from "rehype-slug";
 import rehypeExternalLinks from "rehype-external-links";
-import { H2, H3, H4, Link, ListItem, Code } from "./MdElements";
+import { H2, H3, H4, Link, ListItem, Code, Img } from "./MdElements";
 import {
   FacebookShareButton,
   LinkedinShareButton,
@@ -26,19 +25,15 @@ const Blog = ({
   title,
   description,
   date,
-  ogImage,
   content,
   slug,
 }) => {
   return (
     <article
-      className="prose prose-slate dark:prose-invert prose-lg max-w-none min-w-0 mx-auto
-        prose-headings:font-semibold prose-headings:tracking-tight prose-headings:scroll-mt-24
-        prose-a:font-medium prose-a:no-underline hover:prose-a:underline prose-a:underline-offset-2
-        prose-img:rounded-xl prose-img:shadow-sm
-        prose-hr:border-slate-200 dark:prose-hr:border-slate-700
-        prose-blockquote:border-l-4 prose-blockquote:border-l-blue-500 prose-blockquote:not-italic prose-blockquote:font-normal
-        prose-pre:rounded-xl prose-pre:shadow-sm
+      className="prose prose-slate dark:prose-invert prose-lg max-w-none min-w-0
+        prose-headings:font-sans prose-headings:font-semibold prose-headings:scroll-mt-24
+        prose-img:rounded-xl prose-img:shadow-sm prose-img:ring-1 prose-img:ring-slate-200/70 dark:prose-img:ring-slate-700/50
+        prose-pre:bg-transparent prose-pre:p-0 prose-pre:m-0 prose-pre:rounded-none
         prose-code:before:content-none prose-code:after:content-none prose-code:font-normal"
     >
       <h1 className="mb-3 text-slate-900 dark:text-white font-bold tracking-tight">{title}</h1>
@@ -50,7 +45,6 @@ const Blog = ({
       <p className="not-prose mb-8 text-lg leading-relaxed text-slate-600 dark:text-slate-300">
         {description}
       </p>
-      <Image src={ogImage.url} alt="blog cover" loading="lazy" width={860} height={484} className="w-full h-auto rounded-xl" />
 
       {/* social media sharing buttons */}
       <div className="flex items-center gap-2">
@@ -111,6 +105,7 @@ const Blog = ({
           a: Link,
           li: ListItem,
           code: Code,
+          img: Img,
         }}
       >
         {content}

--- a/components/Blog/Blog.js
+++ b/components/Blog/Blog.js
@@ -2,6 +2,7 @@ import React from "react";
 import Image from "next/image";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import rehypeRaw from "rehype-raw";
 import rehypeSlug from "rehype-slug";
 import rehypeExternalLinks from "rehype-external-links";
 import { H2, H3, H4, Link, ListItem, Code } from "./MdElements";
@@ -102,7 +103,7 @@ const Blog = ({
       <Markdown
         className="text-left"
         remarkPlugins={[remarkGfm]}
-        rehypePlugins={[rehypeSlug, [rehypeExternalLinks, { target: "_blank", rel: ["noopener", "noreferrer"] }]]}
+        rehypePlugins={[rehypeRaw, rehypeSlug, [rehypeExternalLinks, { target: "_blank", rel: ["noopener", "noreferrer"] }]]}
         components={{
           h2: H2,
           h3: H3,

--- a/components/Blog/Blog.js
+++ b/components/Blog/Blog.js
@@ -30,12 +30,26 @@ const Blog = ({
   slug,
 }) => {
   return (
-    <article className="prose min-w-0 mx-auto text-slate-600 dark:text-slate-400">
-      <h1 className="text-4xl text-slate-900 dark:text-white font-bold">{title}</h1>
-      <h4 className="text-sm text-slate-500 dark:text-slate-400">Published on {date}</h4>
-      <h4 className="text-sm text-slate-500 dark:text-slate-400">Reading time: {readingTime}</h4>
-      <h4 className="text-sm text-slate-500 dark:text-slate-400">Description: {description}</h4>
-      <Image src={ogImage.url} alt="blog cover" loading="lazy" width={800} height={450} className="w-full h-auto" />
+    <article
+      className="prose prose-slate dark:prose-invert prose-lg max-w-none min-w-0 mx-auto
+        prose-headings:font-semibold prose-headings:tracking-tight prose-headings:scroll-mt-24
+        prose-a:font-medium prose-a:no-underline hover:prose-a:underline prose-a:underline-offset-2
+        prose-img:rounded-xl prose-img:shadow-sm
+        prose-hr:border-slate-200 dark:prose-hr:border-slate-700
+        prose-blockquote:border-l-4 prose-blockquote:border-l-blue-500 prose-blockquote:not-italic prose-blockquote:font-normal
+        prose-pre:rounded-xl prose-pre:shadow-sm
+        prose-code:before:content-none prose-code:after:content-none prose-code:font-normal"
+    >
+      <h1 className="mb-3 text-slate-900 dark:text-white font-bold tracking-tight">{title}</h1>
+      <div className="not-prose mb-6 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-slate-500 dark:text-slate-400">
+        <span>Published on {date}</span>
+        <span aria-hidden="true">•</span>
+        <span>{readingTime}</span>
+      </div>
+      <p className="not-prose mb-8 text-lg leading-relaxed text-slate-600 dark:text-slate-300">
+        {description}
+      </p>
+      <Image src={ogImage.url} alt="blog cover" loading="lazy" width={860} height={484} className="w-full h-auto rounded-xl" />
 
       {/* social media sharing buttons */}
       <div className="flex items-center gap-2">
@@ -86,7 +100,7 @@ const Blog = ({
       <hr className="rounded text-slate-300 dark:text-slate-400" />
 
       <Markdown
-        className="text-justify"
+        className="text-left"
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeSlug, [rehypeExternalLinks, { target: "_blank", rel: ["noopener", "noreferrer"] }]]}
         components={{

--- a/components/Blog/MdElements.js
+++ b/components/Blog/MdElements.js
@@ -1,5 +1,11 @@
+import { useEffect, useState } from "react";
+import { Check, Copy } from "lucide-react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { oneDark } from "react-syntax-highlighter/dist/cjs/styles/prism";
+import {
+  oneDark,
+  oneLight,
+} from "react-syntax-highlighter/dist/cjs/styles/prism";
+import { useTheme } from "../ThemeToggle";
 
 export const H1 = ({ children, id }) => {
   return (
@@ -45,18 +51,123 @@ export const Link = ({ children, href }) => {
 };
 
 export const ListItem = ({ children }) => {
-  return <li className="text-slate-600 dark:text-slate-400">{children}</li>;
+  return <li className="text-slate-700 dark:text-slate-300">{children}</li>;
+};
+
+// Resolve a size hint into a CSS length: a bare number -> px, a "%" value
+// stays as-is. Returns undefined when no usable hint is present.
+const toCssSize = (value) => {
+  if (value == null) return undefined;
+  const v = String(value).trim();
+  if (/^\d+$/.test(v)) return `${v}px`;
+  if (/^\d+(px|%|rem|em|vw)$/.test(v)) return v;
+  return undefined;
+};
+
+export const Img = ({ src, alt, title, width, height }) => {
+  // Size can be set two ways:
+  //   markdown:  ![alt](src "480")  or  ![alt](src "60%")
+  //   raw HTML:  <img src="..." width="480">  or  width="60%"
+  const w = toCssSize(width) || toCssSize(title);
+  // A numeric/size title is a sizing hint, not a real caption.
+  const isSizeTitle = toCssSize(title) !== undefined;
+
+  return (
+    <img
+      src={src}
+      alt={alt || ""}
+      title={isSizeTitle ? undefined : title}
+      loading="lazy"
+      className="mx-auto block h-auto rounded-xl"
+      style={{ maxWidth: "100%", width: w, height: toCssSize(height) }}
+    />
+  );
 };
 
 export const Code = ({ className, children }) => {
+  const { theme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  const [copied, setCopied] = useState(false);
+  useEffect(() => setMounted(true), []);
   const match = /language-(\w+)/.exec(className || "");
-  return match ? (
-    <SyntaxHighlighter PreTag="div" language={match[1]} style={oneDark}>
-      {String(children).replace(/\n$/, "")}
-    </SyntaxHighlighter>
-  ) : (
-    <code className="rounded bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 text-[0.875em] font-medium text-slate-800 dark:text-slate-200">
-      {children}
-    </code>
+
+  if (!match) {
+    return (
+      <code className="rounded-md border border-slate-200 bg-slate-100 px-1.5 py-0.5 font-mono text-[0.85em] font-medium text-slate-800 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200">
+        {children}
+      </code>
+    );
+  }
+
+  // Before mount, match the server render (ThemeProvider defaults to "dark")
+  // to avoid a hydration mismatch in the syntax highlighter's markup.
+  const isDark = mounted ? theme === "dark" : true;
+  const code = String(children).replace(/\n$/, "");
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+    } catch {
+      // fallback for browsers / contexts without the async clipboard API
+      const ta = document.createElement("textarea");
+      ta.value = code;
+      ta.style.position = "fixed";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      try {
+        document.execCommand("copy");
+      } catch {}
+      document.body.removeChild(ta);
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="not-prose my-6 overflow-hidden rounded-xl border border-slate-200 shadow-sm dark:border-slate-700">
+      {/* editor-style toolbar */}
+      <div className="flex items-center justify-between border-b border-slate-200 bg-slate-50 px-3 py-1.5 dark:border-slate-800 dark:bg-slate-900">
+        <div className="flex gap-1.5">
+          <span className="h-3 w-3 rounded-full bg-red-400/80" />
+          <span className="h-3 w-3 rounded-full bg-yellow-400/80" />
+          <span className="h-3 w-3 rounded-full bg-green-400/80" />
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="font-mono text-xs font-medium uppercase tracking-wider text-slate-400 dark:text-slate-500">
+            {match[1]}
+          </span>
+          <button
+            type="button"
+            onClick={handleCopy}
+            aria-label={copied ? "Copied" : "Copy code"}
+            className="flex items-center gap-1 font-mono text-xs text-slate-400 transition-colors hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-200"
+          >
+            {copied ? (
+              <Check className="h-3.5 w-3.5 text-green-500" />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
+            {copied ? "Copied" : "Copy"}
+          </button>
+        </div>
+      </div>
+      <SyntaxHighlighter
+        PreTag="div"
+        language={match[1]}
+        style={isDark ? oneDark : oneLight}
+        customStyle={{
+          margin: 0,
+          borderRadius: 0,
+          padding: "1rem 1.25rem",
+          fontSize: "0.9rem",
+          lineHeight: 1.6,
+          background: isDark ? "#0f172a" : "#f8fafc",
+        }}
+        codeTagProps={{ style: { fontFamily: "var(--font-mono)" } }}
+      >
+        {code}
+      </SyntaxHighlighter>
+    </div>
   );
 };

--- a/components/Blog/MdElements.js
+++ b/components/Blog/MdElements.js
@@ -35,7 +35,10 @@ export const H4 = ({ children, id }) => {
 
 export const Link = ({ children, href }) => {
   return (
-    <a className="text-blue-600 dark:text-slate-200 break-all" href={href}>
+    <a
+      className="text-blue-600 dark:text-blue-400 font-medium underline decoration-blue-600/30 dark:decoration-blue-400/30 underline-offset-2 hover:decoration-blue-600 dark:hover:decoration-blue-400 break-words"
+      href={href}
+    >
       {children}
     </a>
   );
@@ -52,6 +55,8 @@ export const Code = ({ className, children }) => {
       {String(children).replace(/\n$/, "")}
     </SyntaxHighlighter>
   ) : (
-    <code className="text-slate-700 dark:text-slate-200">{children}</code>
+    <code className="rounded bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 text-[0.875em] font-medium text-slate-800 dark:text-slate-200">
+      {children}
+    </code>
   );
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "reading-time": "^1.5.0",
     "rehype": "^13.0.1",
     "rehype-external-links": "^3.0.0",
+    "rehype-raw": "^7.0.0",
     "rehype-slug": "^6.0.0",
     "remark-capitalize": "^1.1.0",
     "remark-code-titles": "^0.1.2",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,18 +1,24 @@
 import "../styles/globals.css";
-import { Raleway } from "next/font/google";
+import { Raleway, JetBrains_Mono } from "next/font/google";
 import Head from "next/head";
 import Script from "next/script";
 import { DefaultSeo } from "next-seo";
 import SEO from "../next-seo.config";
 import { ThemeProvider } from "../components/ThemeToggle";
 
-const raleway = Raleway({ subsets: ["latin"] });
+const raleway = Raleway({ subsets: ["latin"], variable: "--font-sans" });
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  variable: "--font-mono",
+});
 
 // // This default export is required in a new `pages/_app.js` file.
 export default function MyApp({ Component, pageProps }) {
   return (
     <ThemeProvider>
-      <main className={raleway.className}>
+      <main
+        className={`${raleway.className} ${raleway.variable} ${jetbrainsMono.variable}`}
+      >
         {/* google analytics */}
         <Script
           strategy="afterInteractive"

--- a/pages/blogs/[slug].js
+++ b/pages/blogs/[slug].js
@@ -64,8 +64,8 @@ const BlogPost = ({ readingTime, frontMatter, slug, source, headings }) => {
           images: [{ url: frontMatter.ogImage.url, alt: frontMatter.title }],
         }}
       />
-      <div className="max-w-screen-xl mx-auto py-8 px-4 sm:px-8 xl:px-0">
-        <div className="xl:grid xl:grid-cols-[1fr_minmax(0,720px)_1fr] xl:items-start">
+      <div className="max-w-screen-2xl mx-auto py-8 px-4 sm:px-8 xl:px-0">
+        <div className="xl:grid xl:grid-cols-[1fr_minmax(0,860px)_1fr] xl:items-start">
           <div className="hidden xl:block" />
           <Blog
             readingTime={readingTime}

--- a/pages/blogs/[slug].js
+++ b/pages/blogs/[slug].js
@@ -65,7 +65,7 @@ const BlogPost = ({ readingTime, frontMatter, slug, source, headings }) => {
         }}
       />
       <div className="max-w-screen-2xl mx-auto py-8 px-4 sm:px-8 xl:px-0">
-        <div className="xl:grid xl:grid-cols-[1fr_minmax(0,860px)_1fr] xl:items-start">
+        <div className="xl:grid xl:grid-cols-[1fr_minmax(0,1024px)_1fr] xl:items-start">
           <div className="hidden xl:block" />
           <Blog
             readingTime={readingTime}
@@ -73,7 +73,6 @@ const BlogPost = ({ readingTime, frontMatter, slug, source, headings }) => {
             description={frontMatter.description}
             date={frontMatter.date}
             content={source}
-            ogImage={frontMatter.ogImage}
             slug={slug}
           />
           <div className="hidden xl:block xl:self-stretch">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -129,3 +129,44 @@ color-3 {
   background-image: linear-gradient(to right, #667eea, #764ba2, #6B8DD6, #8E37D7);
   box-shadow: 0 4px 15px 0 rgba(116, 79, 168, 0.75);
 }
+
+/* ---- blog reading refinements ---- */
+
+/* brand-tinted text selection */
+.prose ::selection {
+  background-color: rgba(37, 99, 235, 0.18);
+}
+html.dark .prose ::selection {
+  background-color: rgba(96, 165, 250, 0.28);
+}
+
+/* ==highlight== / <mark> styling */
+.prose mark {
+  background-image: linear-gradient(
+    to bottom,
+    transparent 8%,
+    rgba(250, 204, 21, 0.45) 8%
+  );
+  color: inherit;
+  padding: 0 0.1em;
+  border-radius: 0.1em;
+}
+html.dark .prose mark {
+  background-image: linear-gradient(
+    to bottom,
+    transparent 8%,
+    rgba(250, 204, 21, 0.28) 8%
+  );
+  color: #fde68a;
+}
+
+/* keyboard keys */
+.prose kbd {
+  font-family: var(--font-mono);
+  font-size: 0.8em;
+  padding: 0.15em 0.4em;
+  border-radius: 0.375rem;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--muted));
+  box-shadow: 0 1px 0 1px hsl(var(--border));
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,6 @@
 /** @type {import('tailwindcss').Config} */
+const defaultTheme = require("tailwindcss/defaultTheme");
+
 module.exports = {
   darkMode: ["class"],
   content: [
@@ -13,6 +15,83 @@ module.exports = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ["var(--font-sans)", ...defaultTheme.fontFamily.sans],
+        mono: ["var(--font-mono)", ...defaultTheme.fontFamily.mono],
+      },
+      typography: ({ theme }) => ({
+        DEFAULT: {
+          css: {
+            "--tw-prose-body": theme("colors.slate.700"),
+            "--tw-prose-headings": theme("colors.slate.900"),
+            "--tw-prose-lead": theme("colors.slate.600"),
+            "--tw-prose-links": theme("colors.blue.600"),
+            "--tw-prose-bold": theme("colors.slate.900"),
+            "--tw-prose-counters": theme("colors.slate.400"),
+            "--tw-prose-bullets": theme("colors.slate.300"),
+            "--tw-prose-hr": theme("colors.slate.200"),
+            "--tw-prose-quotes": theme("colors.slate.700"),
+            "--tw-prose-quote-borders": theme("colors.blue.500"),
+            "--tw-prose-captions": theme("colors.slate.500"),
+            "--tw-prose-code": theme("colors.slate.800"),
+            "--tw-prose-th-borders": theme("colors.slate.300"),
+            "--tw-prose-td-borders": theme("colors.slate.200"),
+            maxWidth: "none",
+            // smooth, readable measure and rhythm
+            lineHeight: "1.8",
+            p: { marginTop: "1.1em", marginBottom: "1.1em" },
+            // headings use the Raleway display font
+            "h1, h2, h3, h4": {
+              fontFamily: "var(--font-sans)",
+              letterSpacing: "-0.02em",
+            },
+            h2: {
+              marginTop: "2.2em",
+              paddingBottom: "0.3em",
+              borderBottom: `1px solid ${theme("colors.slate.200")}`,
+            },
+            // links: subtle underline that strengthens on hover
+            a: {
+              textDecorationColor: theme("colors.blue.600 / 35%"),
+              textUnderlineOffset: "2px",
+              fontWeight: "500",
+              transition: "text-decoration-color 0.15s ease",
+            },
+            "a:hover": { textDecorationColor: theme("colors.blue.600") },
+            blockquote: {
+              fontStyle: "normal",
+              fontWeight: "400",
+              borderLeftWidth: "3px",
+              paddingLeft: "1.25em",
+              color: theme("colors.slate.600"),
+            },
+            "blockquote p:first-of-type::before": { content: "none" },
+            "blockquote p:last-of-type::after": { content: "none" },
+          },
+        },
+        invert: {
+          css: {
+            "--tw-prose-body": theme("colors.slate.300"),
+            "--tw-prose-headings": theme("colors.white"),
+            "--tw-prose-lead": theme("colors.slate.400"),
+            "--tw-prose-links": theme("colors.blue.400"),
+            "--tw-prose-bold": theme("colors.white"),
+            "--tw-prose-counters": theme("colors.slate.500"),
+            "--tw-prose-bullets": theme("colors.slate.600"),
+            "--tw-prose-hr": theme("colors.slate.700"),
+            "--tw-prose-quotes": theme("colors.slate.200"),
+            "--tw-prose-quote-borders": theme("colors.blue.400"),
+            "--tw-prose-captions": theme("colors.slate.400"),
+            "--tw-prose-code": theme("colors.slate.100"),
+            "--tw-prose-th-borders": theme("colors.slate.600"),
+            "--tw-prose-td-borders": theme("colors.slate.700"),
+            h2: { borderBottomColor: theme("colors.slate.700") },
+            a: { textDecorationColor: theme("colors.blue.400 / 35%") },
+            "a:hover": { textDecorationColor: theme("colors.blue.400") },
+            blockquote: { color: theme("colors.slate.300") },
+          },
+        },
+      }),
       colors: {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,32 +417,6 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.2.tgz#ff02bc3dc8317cd668dfec247b750ba1f1d62453"
   integrity sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA==
 
-"@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.18":
-  version "4.17.31"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz#a1139efeab4e7323834bb0226e62ac019f474b2f"
-  integrity sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==
-  dependencies:
-    "@types/node" "*"
-    "@types/qs" "*"
-    "@types/range-parser" "*"
-
-"@types/express@*", "@types/express@^4.17.13":
-  version "4.17.14"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.14.tgz#143ea0557249bc1b3b54f15db4c81c3d4eb3569c"
-  integrity sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==
-  dependencies:
-    "@types/body-parser" "*"
-    "@types/express-serve-static-core" "^4.17.18"
-    "@types/qs" "*"
-    "@types/serve-static" "*"
-
-"@types/graceful-fs@^4.1.2":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
-  integrity sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==
-  dependencies:
-    "@types/node" "*"
-
 "@types/hast@^2.0.0":
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.6.tgz#bb8b05602112a26d22868acb70c4b20984ec7086"
@@ -2045,11 +2019,6 @@ hast-util-heading-rank@^3.0.0:
   dependencies:
     "@types/hast" "^3.0.0"
 
-hast-util-is-element@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/hast-util-is-element/-/hast-util-is-element-1.1.0.tgz#3b3ed5159a2707c6137b48637fbfe068e175a425"
-  integrity sha512-oUmNua0bFbdrD/ELDSSEadRVtWZOf3iF6Lbv81naqsIV99RnSCieTbWuWCY8BAeEfKJTKl0gRdokv+dELutHGQ==
-
 hast-util-is-element@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz#6e31a6532c217e5b533848c7e52c9d9369ca0932"
@@ -2161,22 +2130,12 @@ hast-util-to-parse5@^8.0.0:
     web-namespaces "^2.0.0"
     zwitch "^2.0.0"
 
-hast-util-to-string@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/hast-util-to-string/-/hast-util-to-string-1.0.4.tgz#9b24c114866bdb9478927d7e9c36a485ac728378"
-  integrity sha512-eK0MxRX47AV2eZ+Lyr18DCpQgodvaS3fAQO2+b9Two9F5HEoRPhiUMNzoXArMJfZi2yieFzUBMRl3HNJ3Jus3w==
-
 hast-util-to-string@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz#a4f15e682849326dd211c97129c94b0c3e76527c"
   integrity sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==
   dependencies:
     "@types/hast" "^3.0.0"
-
-hast-util-whitespace@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-1.0.4.tgz#e4fe77c4a9ae1cb2e6c25e02df0043d0164f6e41"
-  integrity sha512-I5GTdSfhYfAPNztx2xJRQpG8cuDSNt599/7YUn7Gx/WxNMsG+a835k97TDkFgk123cwjfwINaZknkKkphx/f2A==
 
 hast-util-whitespace@^2.0.0:
   version "2.0.1"
@@ -4223,35 +4182,6 @@ regexp.prototype.flags@^1.5.2:
     es-errors "^1.3.0"
     set-function-name "^2.0.1"
 
-regexpp@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
-  integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
-
-regexpu-core@^5.2.1:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-5.2.2.tgz#3e4e5d12103b64748711c3aad69934d7718e75fc"
-  integrity sha512-T0+1Zp2wjF/juXMrMxHxidqGYn8U4R+zleSJhX9tQ1PUsS8a9UtYfbsF9LdiVgNX3kiX8RNaKM42nfSgvFJjmw==
-  dependencies:
-    regenerate "^1.4.2"
-    regenerate-unicode-properties "^10.1.0"
-    regjsgen "^0.7.1"
-    regjsparser "^0.9.1"
-    unicode-match-property-ecmascript "^2.0.0"
-    unicode-match-property-value-ecmascript "^2.1.0"
-
-regjsgen@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.7.1.tgz#ee5ef30e18d3f09b7c369b76e7c2373ed25546f6"
-  integrity sha512-RAt+8H2ZEzHeYWxZ3H2z6tF18zyyOnlcdaafLrm21Bguj7uZy6ULibiAFdXEtKQY4Sy7wDTwDiOazasMLc4KPA==
-
-regjsparser@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.9.1.tgz#272d05aa10c7c1f67095b1ff0addae8442fc5709"
-  integrity sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==
-  dependencies:
-    jsesc "~0.5.0"
-
 rehype-external-links@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/rehype-external-links/-/rehype-external-links-3.0.0.tgz#2b28b5cda1932f83f045b6f80a3e1b15f168c6f6"
@@ -4264,14 +4194,6 @@ rehype-external-links@^3.0.0:
     space-separated-tokens "^2.0.0"
     unist-util-visit "^5.0.0"
 
-rehype-parse@^7.0.0, rehype-parse@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/rehype-parse/-/rehype-parse-7.0.1.tgz#58900f6702b56767814afc2a9efa2d42b1c90c57"
-  integrity sha512-fOiR9a9xH+Le19i4fGzIEowAbwG7idy2Jzs4mOrFWBSJ0sNUgy0ev871dwWnbOo371SjgjG4pwzrbgSVrKxecw==
-  dependencies:
-    hast-util-from-parse5 "^6.0.0"
-    parse5 "^6.0.0"
-
 rehype-parse@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/rehype-parse/-/rehype-parse-9.0.0.tgz#3949faeec6f466ec57774215661e0d75469195d9"
@@ -4280,6 +4202,15 @@ rehype-parse@^9.0.0:
     "@types/hast" "^3.0.0"
     hast-util-from-html "^2.0.0"
     unified "^11.0.0"
+
+rehype-raw@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/rehype-raw/-/rehype-raw-7.0.0.tgz#59d7348fd5dbef3807bbaa1d443efd2dd85ecee4"
+  integrity sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-raw "^9.0.0"
+    vfile "^6.0.0"
 
 rehype-slug@^6.0.0:
   version "6.0.0"
@@ -4310,11 +4241,6 @@ rehype@^13.0.1:
     rehype-parse "^9.0.0"
     rehype-stringify "^10.0.0"
     unified "^11.0.0"
-
-relateurl@^0.2.7:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
-  integrity sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==
 
 remark-capitalize@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## Summary
Refines the blog reading experience: typography, code blocks, images, and color contrast.

### Layout & typography
- Widen the center reading column and remove the cover image from the post page (still shown in the blog list).
- Refine prose colors for both light/dark, add an `h2` underline, brand-tinted text selection, and `<mark>`/`<kbd>` styling.
- Use **JetBrains Mono** for code (headings stay Raleway, body stays Raleway).

### Code blocks
- Editor-style window with traffic-light dots and a language label.
- **Copy button** with copied-state feedback (async Clipboard API + execCommand fallback).
- **Theme-adaptive** syntax highlighting (oneLight/oneDark) with a mount guard to avoid hydration mismatch.
- Stripped the surrounding Tailwind-typography `<pre>` frame so the window sits flush in the content, with comfortable inner padding.

### Images
- Added an `img` handler so images are centered and responsive, with a size knob:
  - raw HTML: `<img src="..." width="400">` (px, `%`, `rem`, etc.)
  - markdown: `![alt](src "400")` or `![alt](src "60%")`
- Applied widths to the images in the OpenManus post.

### Readability
- Brighten list-item text to match body color (was too dim in dark mode).

## Test plan
- Verified in the local dev preview (light + dark): reading column width, code-block rendering/copy/theme switching, image sizing, and list-text contrast. No console errors.